### PR TITLE
Fix scope error for Behat test

### DIFF
--- a/src/local/obf/tests/behat/behat_local_obf.php
+++ b/src/local/obf/tests/behat/behat_local_obf.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 use Behat\Behat\Context\Step\Given;
-use Behat\Behat\Event\FeatureEvent;
+use Behat\Behat\Hook\Scope\AfterFeatureScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Session;
@@ -43,10 +43,10 @@ class behat_local_obf extends behat_base {
      *
      * Deletion will succeed if behat has entered the request token/API key.
      *
-     * @param FeatureEvent $event
+     * @param AfterFeatureScope $event
      * @AfterFeature
      */
-    public static function teardownFeature(FeatureEvent $event) {
+    public static function teardownFeature(AfterFeatureScope $event) {
         require_once(__DIR__ . '/../../class/client.php');
         try {
             obf_client::get_instance()->delete_badges();


### PR DESCRIPTION
To fix the following the error when running Behat tests:
```
Failed hooks:

    AfterFeature # behat_hooks::after_feature()
      Type error: Argument 1 passed to behat_hooks::after_feature() must be an instance of FeatureEvent, instance of Behat\Behat\Hook\Scope\AfterFeatureScope given (Behat\Testwork\Call\Exception\FatalThrowableError)

    AfterFeature # behat_local_obf::teardownFeature()
      Type error: Argument 1 passed to behat_local_obf::teardownFeature() must be an instance of Behat\Behat\Event\FeatureEvent, instance of Behat\Behat\Hook\Scope\AfterFeatureScope given (Behat\Testwork\Call\Exception\FatalThrowableError)
```
